### PR TITLE
Prevent Users From Reregistering

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -3,7 +3,7 @@ import { Db } from "mongodb";
 
 import { MessageExecutable } from "./command";
 
-class NewSubcommand extends MessageExecutable<CommandInteraction> {
+class NewUserSubcommand extends MessageExecutable<CommandInteraction> {
     async execute() {
         const gameTag = this.interaction.options.getString("val_id");
         const pronouns = this.interaction.options.getString("pronouns");
@@ -48,7 +48,7 @@ class NewSubcommand extends MessageExecutable<CommandInteraction> {
     }
 }
 
-class UpdateSubcommand extends MessageExecutable<CommandInteraction> {
+class UpdateUserSubcommand extends MessageExecutable<CommandInteraction> {
     async execute() {
         const gameTag =
             this.interaction.options.getString("val_id") || undefined;
@@ -88,12 +88,12 @@ class UpdateSubcommand extends MessageExecutable<CommandInteraction> {
 
 function cmd_register(interaction, db: Db) {
     const commands = {
-        "new": NewSubcommand,
-        "update": UpdateSubcommand
+        "new": NewUserSubcommand,
+        "update": UpdateUserSubcommand
     };
 
-    const call_fn = commands[interaction.options.getSubcommand()];
-    const subcmd: MessageExecutable<CommandInteraction> = new call_fn(interaction, db);
+    const Action = commands[interaction.options.getSubcommand()];
+    const subcmd: MessageExecutable<CommandInteraction> = new Action(interaction, db);
     subcmd.execute();
 }
 

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,7 +1,9 @@
+import { CommandInteraction, Message } from "discord.js";
 import { Db } from "mongodb";
-import { Subcommand } from "./command";
 
-class NewSubcommand extends Subcommand {
+import { MessageExecutable } from "./command";
+
+class NewSubcommand extends MessageExecutable<CommandInteraction> {
     async execute() {
         const gameTag = this.interaction.options.getString("val_id");
         const pronouns = this.interaction.options.getString("pronouns");
@@ -9,7 +11,7 @@ class NewSubcommand extends Subcommand {
             discordId: this.interaction.user.id
         }).toArray();
 
-        // Exit in case data for a user already exists
+        // Exit if data for a user already exists
         if (existing_user.length > 0) {
             this.interaction.reply({
                 content:
@@ -46,7 +48,7 @@ class NewSubcommand extends Subcommand {
     }
 }
 
-class UpdateSubcommand extends Subcommand {
+class UpdateSubcommand extends MessageExecutable<CommandInteraction> {
     async execute() {
         const gameTag =
             this.interaction.options.getString("val_id") || undefined;
@@ -91,7 +93,7 @@ function cmd_register(interaction, db: Db) {
     };
 
     const call_fn = commands[interaction.options.getSubcommand()];
-    const subcmd: Subcommand = new call_fn(interaction, db);
+    const subcmd: MessageExecutable<CommandInteraction> = new call_fn(interaction, db);
     subcmd.execute();
 }
 

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -7,12 +7,12 @@ class NewSubcommand extends MessageExecutable<CommandInteraction> {
     async execute() {
         const gameTag = this.interaction.options.getString("val_id");
         const pronouns = this.interaction.options.getString("pronouns");
-        const existing_user = await this.db.collection("members").find({
+        const existingUser = await this.db.collection("members").findOne({
             discordId: this.interaction.user.id
-        }).toArray();
+        });
 
         // Exit if data for a user already exists
-        if (existing_user.length > 0) {
+        if (!!existingUser) {
             this.interaction.reply({
                 content:
                     "I already know **exactly** who you are. No need to register again, my friend!",

--- a/src/commands/tenmans.ts
+++ b/src/commands/tenmans.ts
@@ -12,7 +12,7 @@ let tenmansQueue: Set<string> = new Set();
 let time: String | null;
 let activeTenmansMessage: Message | null;
 
-abstract class SubcommandTenmansQueue extends RegisteredUserSubcommand {
+abstract class TenmansQueueSubcommand extends RegisteredUserSubcommand {
   abstract updateQueue();
 
   afterUserExecute(): Promise<any> {
@@ -32,7 +32,7 @@ abstract class SubcommandTenmansQueue extends RegisteredUserSubcommand {
   }
 }
 
-class SubcommandTenmansJoin extends SubcommandTenmansQueue {
+class TenmansJoinSubcommand extends TenmansQueueSubcommand {
   updateQueue() {
     tenmansQueue.add(this.user.gameTag);
     this.interaction.reply({
@@ -42,7 +42,7 @@ class SubcommandTenmansJoin extends SubcommandTenmansQueue {
   }
 }
 
-class SubcommandTenmansLeave extends SubcommandTenmansQueue {
+class TenmansLeaveSubcommand extends TenmansQueueSubcommand {
   updateQueue() {
     tenmansQueue.delete(this.user.gameTag);
     this.interaction.reply({
@@ -52,7 +52,7 @@ class SubcommandTenmansLeave extends SubcommandTenmansQueue {
   }
 }
 
-class SubcommandTenmansStart extends Subcommand {
+class TenmansStartSubcommand extends Subcommand {
   async execute(): Promise<any> {
     const interaction_user = this.interaction.user;
     const role = this.interaction.guild.roles.cache.find(
@@ -88,9 +88,9 @@ async function cmd_tenmans(interaction, db: Db) {
       new (interaction: CommandInteraction, db: Db): Subcommand;
     };
   } = {
-    join: SubcommandTenmansJoin,
-    leave: SubcommandTenmansLeave,
-    start: SubcommandTenmansStart,
+    join: TenmansJoinSubcommand,
+    leave: TenmansLeaveSubcommand,
+    start: TenmansStartSubcommand,
   };
 
   // Wrap function call to pass same args to all methods


### PR DESCRIPTION
Modifies: `register` command

Add a check to the user database to see if a user already exists before registering their data again.

While I was in there, I also refactored the subcommands to match the OOP structures seen in the `tenmans` command source.

Closes #2.