### PR TITLE
Add Bot Configuration Data With Associated Command

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { Client, Intents } from "discord.js";
+import { config } from "dotenv";
 import { Db } from "mongodb";
 
 import cmd_register from "./commands/register";
@@ -6,12 +7,37 @@ import {
   cmd_tenmans,
   handleButton as tenmansHandleButton,
 } from "./commands/tenmans";
+import botConfig from "./config/botConfig";
+
+async function initBotConfig (client: Client, db: Db) {
+  const botConfigCollection = db.collection("config");
+  let botConfigDoc = await botConfigCollection.findOne({
+    "configName": "bot"
+  });
+    
+  if (!!botConfigDoc) {
+    // Persist default configuration data
+    const defaultChannelId = process.env.DEFAULT_QUEUEMSG_CHANNELID || "885704092142428200";
+
+    botConfigDoc = await botConfigCollection.insertOne({
+      "configName": "bot",
+      "queueChannelId": defaultChannelId
+    });
+  }
+
+  const channelId = botConfigDoc.queueChannelId;
+  botConfig.queueMsgChannel = client.channels.cache.get(channelId);
+}
 
 export default (db: Db) => {
   const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
-  client.on("ready", () => {
+  client.on("ready", async () => {
     console.log(`Logged in as ${client.user.tag}!`);
+    
+    console.log(`Loading configuration data from db...`);
+    await initBotConfig(this, db);
+    console.log(`Config successfully initialized.`);
   });
 
   client.on("interactionCreate", async (interaction) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
   cmd_tenmans,
   handleButton as tenmansHandleButton,
 } from "./commands/tenmans";
+import { cmdConfig } from "./commands/config";
 import botConfig from "./config/botConfig";
 
 async function initBotConfig (client: Client, db: Db) {
@@ -15,7 +16,7 @@ async function initBotConfig (client: Client, db: Db) {
     "configName": "bot"
   });
     
-  if (!!botConfigDoc) {
+  if (!botConfigDoc) {
     // Persist default configuration data
     const defaultChannelId = process.env.DEFAULT_QUEUEMSG_CHANNELID || "885704092142428200";
 
@@ -45,6 +46,7 @@ export default (db: Db) => {
       const actions = {
         register: cmd_register,
         tenmans: cmd_tenmans,
+        config: cmdConfig
       };
 
       // Use function table to pass context to specific command

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,19 +10,20 @@ import {
 import { cmdConfig } from "./commands/config";
 import botConfig from "./config/botConfig";
 
-async function initBotConfig (client: Client, db: Db) {
+async function initBotConfig(client: Client, db: Db) {
   const botConfigCollection = db.collection("config");
   let botConfigDoc = await botConfigCollection.findOne({
-    "configName": "bot"
+    configName: "bot",
   });
-    
+
   if (!botConfigDoc) {
     // Persist default configuration data
-    const defaultChannelId = process.env.DEFAULT_QUEUEMSG_CHANNELID || "885704092142428200";
+    const defaultChannelId =
+      process.env.DEFAULT_QUEUEMSG_CHANNELID || "885704092142428200";
 
     botConfigDoc = await botConfigCollection.insertOne({
-      "configName": "bot",
-      "queueChannelId": defaultChannelId
+      configName: "bot",
+      queueChannelId: defaultChannelId,
     });
   }
 
@@ -35,7 +36,7 @@ export default (db: Db) => {
 
   client.on("ready", async () => {
     console.log(`Logged in as ${client.user.tag}!`);
-    
+
     console.log(`Loading configuration data from db...`);
     await initBotConfig(this, db);
     console.log(`Config successfully initialized.`);
@@ -46,7 +47,7 @@ export default (db: Db) => {
       const actions = {
         register: cmd_register,
         tenmans: cmd_tenmans,
-        config: cmdConfig
+        config: cmdConfig,
       };
 
       // Use function table to pass context to specific command

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,7 +19,7 @@ async function initBotConfig(client: Client, db: Db) {
   if (!botConfigDoc) {
     // Persist default configuration data
     const defaultChannelId =
-      process.env.DEFAULT_QUEUEMSG_CHANNELID || "885704092142428200";
+      process.env.DEFAULT_QUEUEMSG_CHANNELID;
 
     botConfigDoc = await botConfigCollection.insertOne({
       configName: "bot",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,73 @@
+import { Channel, CommandInteraction, Interaction } from "discord.js";
+import { Db } from "mongodb";
+import { MessageExecutable } from "./command";
+
+import botConfig from "../config/botConfig";
+
+class DefaultChannelSubcommand extends MessageExecutable<CommandInteraction> {
+  async execute() {
+    const interaction_user = this.interaction.user;
+    const role = this.interaction.guild.roles.cache.find(
+      (role) => role.name === "Admin"
+    );
+
+    if (
+      !this.interaction.guild.members.cache
+        .get(interaction_user.id)
+        .roles.cache.has(role.id)
+    ) {
+      this.interaction.reply({
+        content: "Only admins can execute this command.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const channel = this.interaction.options.getChannel("channel") as Channel;
+    if (!channel) {
+      this.interaction.reply({
+        content: "Provided channel was not valid. Please check logs for help.",
+        ephemeral: true,
+      });
+
+      console.log(this.interaction.options);
+    }
+
+    botConfig.queueMsgChannel = channel;
+
+    // Persist channel
+    this.db.collection("config").updateOne(
+      {
+        "configName": "bot"
+      }, {
+        "queueChannelId": botConfig.queueMsgChannel.id
+      }
+    );
+  }
+}
+
+export async function cmdConfig(interaction, db: Db) {
+  const commands: {
+    [key: string]: {
+      new (
+        interaction: Interaction,
+        db: Db
+      ): MessageExecutable<CommandInteraction>;
+    };
+  } = {
+    defaultChannel: DefaultChannelSubcommand,
+  };
+  
+  // Wrap function call to pass same args to all methods
+  const Action = commands[interaction.options.getSubcommand()];
+  if (Action === undefined) {
+    console.error("Bad action:", interaction.options.getSubcommand());
+    interaction.reply({
+      ephemeral: true,
+      content: "Error logged; please tell an admin what you were trying to do."
+    });
+    return;
+  }
+  const command = new Action(interaction, db);
+  command.execute();
+}

--- a/src/commands/tenmans.ts
+++ b/src/commands/tenmans.ts
@@ -10,6 +10,7 @@ import {
   Interaction,
 } from "discord.js";
 import { Db } from "mongodb";
+import botConfig from "../config/botConfig";
 import Member from "../models/member";
 
 import {
@@ -91,9 +92,7 @@ class SubcommandTenmansStart extends MessageExecutable<CommandInteraction> {
     }
     time = this.interaction.options.getString("time");
     tenmansQueue = [];
-    const queueChannel = this.interaction.guild.channels.cache.get(
-      "885704092142428200"
-    ) as TextChannel;
+    const queueChannel = botConfig.queueMsgChannel as TextChannel;
 
     const queueId = "stub";
 

--- a/src/commands/tenmans.ts
+++ b/src/commands/tenmans.ts
@@ -93,6 +93,13 @@ class SubcommandTenmansStart extends MessageExecutable<CommandInteraction> {
     time = this.interaction.options.getString("time");
     tenmansQueue = [];
     const queueChannel = botConfig.queueMsgChannel as TextChannel;
+    if (!queueChannel) {
+      this.interaction.reply({
+        content:
+          "No queue message channel configured. Please set channel id using '/config defaultChannel'.",
+        ephemeral: true,
+      });
+    }
 
     const queueId = "stub";
 
@@ -121,7 +128,7 @@ export async function cmd_tenmans(interaction, db: Db) {
     console.error("Bad action:", interaction.options.getSubcommand());
     interaction.reply({
       ephemeral: true,
-      content: "Error logged; please tell an admin what you were trying to do"
+      content: "Error logged; please tell an admin what you were trying to do",
     });
     return;
   }
@@ -149,7 +156,7 @@ export async function handleButton(interaction: ButtonInteraction, db: Db) {
     console.error("Bad action:", interaction.customId);
     interaction.reply({
       ephemeral: true,
-      content: "Error logged; please tell an admin what you were trying to do"
+      content: "Error logged; please tell an admin what you were trying to do",
     });
     return;
   }

--- a/src/config/botConfig.ts
+++ b/src/config/botConfig.ts
@@ -1,0 +1,9 @@
+import { Channel } from "discord.js";
+
+class BotConfig {
+    constructor(
+        public queueMsgChannel ?:Channel
+    ) {}
+}
+
+export default new BotConfig();

--- a/src/config/botConfig.ts
+++ b/src/config/botConfig.ts
@@ -1,9 +1,7 @@
 import { Channel } from "discord.js";
 
 class BotConfig {
-    constructor(
-        public queueMsgChannel ?:Channel
-    ) {}
+  constructor(public queueMsgChannel?: Channel) {}
 }
 
 export default new BotConfig();

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,14 @@ const commands = [
       {
         name: "defaultChannel",
         description: "The channel to place queue embed messages",
-        type: ApplicationCommandOptionType.Channel
+        type: ApplicationCommandOptionType.Subcommand,
+        options: [
+          {
+            name: "channel",
+            description: "Channel to place messages",
+            type: ApplicationCommandOptionType.Channel
+          }
+        ]
       }
     ]
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,17 @@ const commands = [
         ]
       }
     ]
+  },
+  {
+    name: "config",
+    description: "Configure Cypher Bot settings via subcommands",
+    options: [
+      {
+        name: "defaultChannel",
+        description: "The channel to place queue embed messages",
+        type: ApplicationCommandOptionType.Channel
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Adds a singleton bot configuration object for use in all bot commands and actions.
Adds a config command that allows the user to specify a channel that should be used to send queue embeds.

Users will be able to specify the `DEFAULT_QUEUEMSG_CHANNELID` in their `.env` file to set the default channel when the bot spins up.

Closes #5 .